### PR TITLE
blacklist -> Deny

### DIFF
--- a/rotary_irq_esp.py
+++ b/rotary_irq_esp.py
@@ -12,17 +12,17 @@ from machine import Pin
 from rotary import Rotary
 from sys import platform
 
-_esp8266_blacklist_pins = [16]
+_esp8266_deny_pins = [16]
 
 class RotaryIRQ(Rotary): 
     
     def __init__(self, pin_num_clk, pin_num_dt, min_val=0, max_val=10, reverse=False, range_mode=Rotary.RANGE_UNBOUNDED):
         
         if platform == 'esp8266':
-            if pin_num_clk in _esp8266_blacklist_pins:
-                raise ValueError('%s: Pin %d not allowed. Blacklist: %s' % (platform, pin_num_clk,_esp8266_blacklist_pins))
-            if pin_num_dt in _esp8266_blacklist_pins:
-                raise ValueError('%s: Pin %d not allowed. Blacklist: %s' % (platform, pin_num_dt,_esp8266_blacklist_pins))
+            if pin_num_clk in _esp8266_deny_pins:
+                raise ValueError('%s: Pin %d not allowed. Not Available for Interrupt: %s' % (platform, pin_num_clk,_esp8266_deny_pins))
+            if pin_num_dt in _esp8266_deny_pins:
+                raise ValueError('%s: Pin %d not allowed. Not Available for Interrupt: %s' % (platform, pin_num_dt,_esp8266_deny_pins))
 
         super().__init__(min_val, max_val, reverse, range_mode)
         self._pin_clk = Pin(pin_num_clk, Pin.IN)


### PR DESCRIPTION
More meaningful error message, there's a clear reason not to use Pin 16, and it now follows 2020-safe vocabulary